### PR TITLE
Encode the search query before appending it

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,5 +6,5 @@ document.getElementById("search").addEventListener("keypress", function(event) {
 });
 
 function search() {
-  window.location.href = "https://duckduckgo.com/?q=" + document.getElementById("search").value;
+  window.location.href = "https://duckduckgo.com/?q=" + encodeURIComponent(document.getElementById("search").value);
 }


### PR DESCRIPTION
This allows users to make searches that include characters such as "&".